### PR TITLE
Account for strings in mouse actions

### DIFF
--- a/twiddler_config/config.py
+++ b/twiddler_config/config.py
@@ -379,6 +379,9 @@ class Config:
             type_byte = chord_bytes[2]
             if type_byte == 0xff:
                 string_chord_count += 1
+        for mouse_action_int in [mouse_left_action, mouse_middle_action, mouse_right_action]:
+            if mouse_action_int & 0xff == 0xff:
+                string_chord_count += 1
 
         string_table_bytes = file_obj.read(string_chord_count * 4)
         string_table = [


### PR DESCRIPTION
Attempting to parse the [CoolHand](https://github.com/CoohLand/CoolHand) config raises an exception as the code attempts to read beyond the end of the file.

The CoolHand config has one of the mouse actions mapped to a string, and mouse actions are not considered when computing the size of the string location table.

This patch increments `string_chord_count` for each mouse action that references a string. 